### PR TITLE
problem statement, json default, generateResponse, tempature=0

### DIFF
--- a/app.js
+++ b/app.js
@@ -10,6 +10,8 @@ import v1EngineGenerate from './routes/v1/engineGenerate.js'
 const app = express()
 
 app.use(cors())
+app.use(express.json());
+app.use(express.urlencoded({ extended: true }));
 
 if (app.get('env') === 'production') {
   app.set('trust proxy', 1) // trust first proxy

--- a/engines/default/engine.js
+++ b/engines/default/engine.js
@@ -54,6 +54,14 @@ class Engine {
                 label: "Prompt Scheme",
                 description: "The collection of templates you want your queries to use.  These templates instruct the OpenAI model how to respond to your queries."
             },{
+                name: "problemStatement",
+                type: "string",
+                required: false,
+                uiElement: "textarea",
+                saveForUser: "local",
+                label: "Problem Statement",
+                description: "Description of a dynamic issue within the system you are studying that highlights an undesirable behavior over time."
+            },{
                 name: "backgroundKnowledge",
                 type: "string",
                 required: false,
@@ -70,15 +78,18 @@ class Engine {
         const promptSchemeId = parameters.promptSchemeId;
         const openAIKey = parameters.openAIKey;
         const backgroundKnowledge = parameters.backgroundKnowledge;
+        const problemStatement = parameters.problemStatement;
 
         try {
-            let wrapper = new OpenAIWrapper(openAIModel, promptSchemeId, backgroundKnowledge, openAIKey);
+            let wrapper = new OpenAIWrapper(openAIModel, promptSchemeId, backgroundKnowledge, problemStatement, openAIKey);
             const relationships = await wrapper.generateDiagram(prompt, currentModel);
             const variables =  [...new Set([...relationships.map( e => e.start),...relationships.map( e => e.end )])];
             return {
                 success: true,
-                relationships: relationships,
-                variables: variables
+                model: {
+                    relationships: relationships,
+                    variables: variables
+                }
             };
         } catch(err) {
             console.error(err);

--- a/engines/default/prompts/default/problemStatement.txt
+++ b/engines/default/prompts/default/problemStatement.txt
@@ -1,0 +1,3 @@
+The user has stated that they are conducting this modeling exercise to understand the following problem better.
+
+{problemStatement}

--- a/engines/default/prompts/maximum feedback/problemStatement.txt
+++ b/engines/default/prompts/maximum feedback/problemStatement.txt
@@ -1,0 +1,3 @@
+The user has stated that they are conducting this modeling exercise to understand the following problem better.
+
+{problemStatement}

--- a/engines/default/utils.js
+++ b/engines/default/utils.js
@@ -44,6 +44,7 @@ async function setupPromptingSchemes() {
       const feedbackPrompt = fs.readFileSync(dirname + subDir + "/feedback.txt", 'utf-8'); 
       const assistantPrompt = fs.readFileSync(dirname + subDir + "/assistant.txt", 'utf-8'); 
       const backgroundPrompt = fs.readFileSync(dirname + subDir + "/background.txt", 'utf-8');
+      const problemStatementPrompt = fs.readFileSync(dirname + subDir + "/problemStatement.txt", 'utf-8');
       const schemaStrings = fs.readFileSync(dirname + subDir + "/schemaStrings.json", 'utf-8');
 
       response[subDir] = {
@@ -52,6 +53,7 @@ async function setupPromptingSchemes() {
         feedbackPrompt: feedbackPrompt,
         assistantPrompt: assistantPrompt,
         backgroundPrompt: backgroundPrompt,
+        problemStatementPrompt: problemStatementPrompt,
         schemaStrings: JSON.parse(schemaStrings)
       };
     });

--- a/engines/predprey/engine.js
+++ b/engines/predprey/engine.js
@@ -10,34 +10,36 @@ class Engine {
     async generate(prompt, currentModel, parameters) {
         return {
             success: true,
-            variables: [
-                {
-                    name: "predator",
-                    type: "variable"
-                },
-                {
-                    name: "prey",
-                    type: "variable"
-                }
-            ],
-            relationships: [
-                {
-                    start: "predator",
-                    end: "prey",
-                    polarity: "-",
-                    reasoning: "As the number of predators increases the number of prey decreases because they get eaten.",
-                    polarityReasoning: "The polarity is - because as predators goes up prey goes down",
-                    relevantText: "There is no relevant text, this is a dummy engine"
-                },
-                {
-                    start: "prey",
-                    end: "predator",
-                    polarity: "+",
-                    reasoning: "As the number of prey increases the number of predators increase because they have more food.",
-                    polarityReasoning: "The polarity is + because as prey goes up predators goes up",
-                    relevantText: "There is no relevant text, this is a dummy engine"
-                }
-            ]
+            model: {
+                variables: [
+                    {
+                        name: "predator",
+                        type: "variable"
+                    },
+                    {
+                        name: "prey",
+                        type: "variable"
+                    }
+                ],
+                relationships: [
+                    {
+                        start: "predator",
+                        end: "prey",
+                        polarity: "-",
+                        reasoning: "As the number of predators increases the number of prey decreases because they get eaten.",
+                        polarityReasoning: "The polarity is - because as predators goes up prey goes down",
+                        relevantText: "There is no relevant text, this is a dummy engine"
+                    },
+                    {
+                        start: "prey",
+                        end: "predator",
+                        polarity: "+",
+                        reasoning: "As the number of prey increases the number of predators increase because they have more food.",
+                        polarityReasoning: "The polarity is + because as prey goes up predators goes up",
+                        relevantText: "There is no relevant text, this is a dummy engine"
+                    }
+                ]
+            }
         }
     }
 }

--- a/routes/v1/engineGenerate.js
+++ b/routes/v1/engineGenerate.js
@@ -8,8 +8,7 @@ router.post("/:engine/generate", async (req, res) => {
     const engine = await import(`./../../engines/${req.params.engine}/engine.js`);
     const instance = new engine.default();
 
-    const prompt = req.body.prompt; 
-    const currentModelJSON = req.body.currentModel;
+    const prompt = req.body.prompt;
     let format = req.body.format;
   
     const engineSpecificParameters = Object.fromEntries(Object.entries(req.body).filter(([k, v]) => {
@@ -17,24 +16,20 @@ router.post("/:engine/generate", async (req, res) => {
     }));
 
     let currentModel = {variables: [], relationships: []};
-    try {
-      currentModel = JSON.parse(currentModelJSON);
-    } catch (err) {
+    if ('currentModel' in req.body) {
+      currentModel = req.body.currentModel
+    }
+  
+    let generateResponse = await instance.generate(prompt, currentModel, engineSpecificParameters);
+  
+    if (generateResponse.err) {
       return res.send({
         success: false,
-        message: "Bad JSON format for currentModel: " + err.toString()
+        message: "Failed to generate a diagram: " + generateResponse.err
       })
     }
   
-    let model = await instance.generate(prompt, currentModel, engineSpecificParameters);
-  
-    if (model.err) {
-      return res.send({
-        success: false,
-        message: "Failed to generate a diagram: " + model.err
-      })
-    }
-  
+    let model = generateResponse.model
     if (format == "xmile") {
       model = utils.convertToXMILE(model)
     } else {


### PR DESCRIPTION
# Changes
- supporting a problem statement in very similar fashion to how background knowledge is supported
- reintroducing default json parsing for express
- pass current model as json rather than string
- noticed we're returning `{success: true: model: {success: true, ...}}`, reworked things a bit to clean that up
- switched temperature to zero to increase accuracy a bit 